### PR TITLE
Clear out default sorts if there is a sort param

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    filterable (0.2.3)
+    filterable (0.2.5)
       rails (> 4.2.0)
 
 GEM
@@ -115,4 +115,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.13.1
+   1.13.6

--- a/lib/filterable.rb
+++ b/lib/filterable.rb
@@ -8,6 +8,7 @@ module Filterable
   extend ActiveSupport::Concern
 
   def filtrate(collection)
+    collection.reorder!('') if !sort_params.blank? && sorts_exist?
     Filtrator.filter(collection, filter_params, filters, sort_params)
   end
 

--- a/lib/filterable/filtrator.rb
+++ b/lib/filterable/filtrator.rb
@@ -17,6 +17,7 @@ module Filterable
     end
 
     def filter
+      collection.reorder!('') unless @sort.blank?
       active_filters.reduce(collection) do |col, filter|
         apply(col, filter)
       end

--- a/lib/filterable/filtrator.rb
+++ b/lib/filterable/filtrator.rb
@@ -17,7 +17,6 @@ module Filterable
     end
 
     def filter
-      collection.reorder!('') unless @sort.blank?
       active_filters.reduce(collection) do |col, filter|
         apply(col, filter)
       end

--- a/lib/filterable/version.rb
+++ b/lib/filterable/version.rb
@@ -1,3 +1,3 @@
 module Filterable
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -162,4 +162,14 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(@response.body)
     assert_equal json, expected_json
   end
+
+  test 'it clears the default sort if sort params exist' do
+    foo_post = Post.create!(title: "foo")
+    bar_post = Post.create!(title: "bar")
+    get('/posts', params: { sort: "-title" })
+    json = JSON.parse(@response.body)
+    json_ids = json.map{ |p| p["id"] }
+
+    assert_equal [foo_post.id, bar_post.id], json_ids
+  end
 end

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -1,4 +1,8 @@
 class Post < ApplicationRecord
+  def self.default_scope
+    order('created_at DESC')
+  end
+
   scope :expired_before, -> (date) {
     where('expiration < ?', date)
   }

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -24,12 +24,12 @@ class FiltratorTest < ActiveSupport::TestCase
   end
 
   test 'it returns default when filter param not passed' do
-    Post.create!(body: "foo")
-    Post.create!(body: "bar")
+    foo_post = Post.create!(body: "foo")
+    bar_post = Post.create!(body: "bar")
     filter = Filterable::Filter.new(:body2, :scope, :body2, ->(c) { c.order(:body) })
     collection = Filterable::Filtrator.filter(Post.all, {}, [filter])
 
-    assert_equal [Post.second, Post.first], collection.to_a
+    assert_equal [bar_post, foo_post], collection.to_a
   end
 
   test 'it will not return default if param passed' do
@@ -39,14 +39,5 @@ class FiltratorTest < ActiveSupport::TestCase
     collection = Filterable::Filtrator.filter(Post.all, { body2: "bar" }, [filter])
 
     assert_equal Post.where(id: filtered_post.id).to_a, collection.to_a
-  end
-
-  test 'it will clear default order if sort param is passed in' do
-    Post.create!(body: "foo")
-    Post.create!(body: "bar")
-    filter = Filterable::Sort.new(:body, :string, :body)
-    collection = Filterable::Filtrator.filter(Post.all.order(:id), {}, [filter], ['body'])
-
-    assert_equal [Post.second, Post.first], collection.to_a
   end
 end

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -40,4 +40,13 @@ class FiltratorTest < ActiveSupport::TestCase
 
     assert_equal Post.where(id: filtered_post.id).to_a, collection.to_a
   end
+
+  test 'it will clear default order if sort param is passed in' do
+    Post.create!(body: "foo")
+    Post.create!(body: "bar")
+    filter = Filterable::Sort.new(:body, :string, :body)
+    collection = Filterable::Filtrator.filter(Post.all.order(:id), {}, [filter], ['body'])
+
+    assert_equal [Post.second, Post.first], collection.to_a
+  end
 end


### PR DESCRIPTION
Use case: Project transmittals have a default sort order (created_at), but I want this to be overridden if we pass a sort parameter in, and I don't want to have to check for sort params in the controller when sort happens elsewhere. So, this change will wipe an existing order on a collection IF there is a sort param passed in.