### PR TITLE
Version bump

### DIFF
--- a/lib/filterable/version.rb
+++ b/lib/filterable/version.rb
@@ -1,3 +1,3 @@
 module Filterable
-  VERSION = '0.2.7'
+  VERSION = '0.2.8'
 end


### PR DESCRIPTION
For applications (like marketplace) upgraded to Rails 5.1+, the gem won't update without a version bump so this is erroring out.