### PR TITLE
Scopes with no arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ pass to a scope filter will be used as arguments to that scope. For example:
 ```ruby
 class Post < ActiveRecord::Base
   scope :with_body, ->(text) { where(body: text) }
+  scope :published, -> { where(published: true) }
 end
 
 class PostsController < ApplicationController
   include Filterable
 
   filter_on :with_body, type: :text
+  filter_on :published, type: :scope
 
   def index
     render json: filtrate(Post.all)
@@ -71,7 +73,9 @@ Passing `?filters[with_body]=my_text` will call the `with_body` scope with
 `my_text` as the argument. If you have a scope that takes multiple arguments,
 you can pass an array of arguments instead of a single argument.
 
-Scopes that accept no arguments are currently not supported.
+When the scope doesn't have any arguments, simply pass any value in the query
+string to use it. `filters[published]=true` and `filters[published]=stuff` have
+the same result when the scope on the model doesn't have any arguments.
 
 ### Sort Types
 Every sort must have a type, so that Filterable knows what to do with it. The current valid sort types are:

--- a/lib/filterable/filter.rb
+++ b/lib/filterable/filter.rb
@@ -51,7 +51,11 @@ module Filterable
     def apply!(collection, value:, active_sorts_hash:)
       if type == :scope
         if value.present?
-          collection.public_send(internal_name, parameter(value))
+          begin
+            collection.public_send(internal_name, parameter(value))
+          rescue ArgumentError
+            collection.public_send(internal_name)
+          end
         elsif default.present?
           default.call(collection)
         else

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -92,6 +92,17 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, json.size
   end
 
+  test 'it filters on named scope without arguments' do
+    Post.create!(published_at: DateTime.now)
+    Post.create!(published_at: nil)
+    Post.create!(published_at: nil)
+
+    get('/posts', params: { filters: { published: true } })
+
+    json = JSON.parse(@response.body)
+    assert_equal 1, json.size
+  end
+
   test 'the param can have a different name from the internal name' do
     post = Post.create!(title: 'hi')
     Post.create!(title: 'friend')

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -11,6 +11,7 @@ class PostsController < ApplicationController
   filter_on :hidden_after, type: :time
   filter_on :published_at, type: :datetime
   filter_on :expired_before, type: :scope
+  filter_on :published, type: :scope
 
   filter_on :french_bread, type: :string, internal_name: :title
   filter_on :body2, type: :scope, internal_name: :body2, default: ->(c) { c.order(:body) }

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -11,6 +11,10 @@ class Post < ApplicationRecord
     where(body: text, priority: priority)
   }
 
+  scope :published, -> {
+    where.not(published_at: nil)
+  }
+
   scope :order_on_body_no_params, -> {
     order(body: :desc)
   }


### PR DESCRIPTION
Adds support for scopes that don't have any arguments. The scope name must simply be present in the query string with any value. For example, if the model has a scope named `published` and the controller defined a filter with `filter_on :published, type: :scope` then the query string `filter[published]=true` and `filter[published]=whatever` have the same result.

Normally I would check the arity of a method to determine if it takes arguments, but there are apparently issues with checking the arity of scopes defined with the `scope` class method that haven't been resolved: https://github.com/rails/rails/issues/28198