### PR TITLE
IAM-1123/allow access to params

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Passing `?sort=order_by_body_then_id` will call the `order_on_body_then_id` scop
 
 Scopes that accept no arguments are currently supported, but you should note that the user has no say in which direction it will sort on.
 
+`scope_params` can also accept symbols that are keys in the `params` hash. The value will be fetched and passed on as an argument to the scope.
+
 
 ## Consumer Usage
 

--- a/bin/test
+++ b/bin/test
@@ -4,6 +4,6 @@ $LOAD_PATH << File.expand_path(File.expand_path('../../test', __FILE__))
 require 'bundler/setup'
 require 'rails/test_unit/minitest_plugin'
 
-Rails::TestUnitReporter.executable = 'bin/test'
+#Rails::TestUnitReporter.executable = 'bin/test'
 
 exit Minitest.run(ARGV)

--- a/bin/test
+++ b/bin/test
@@ -4,6 +4,4 @@ $LOAD_PATH << File.expand_path(File.expand_path('../../test', __FILE__))
 require 'bundler/setup'
 require 'rails/test_unit/minitest_plugin'
 
-#Rails::TestUnitReporter.executable = 'bin/test'
-
 exit Minitest.run(ARGV)

--- a/lib/filterable.rb
+++ b/lib/filterable.rb
@@ -8,7 +8,7 @@ module Filterable
   extend ActiveSupport::Concern
 
   def filtrate(collection)
-    Filtrator.filter(collection, filter_params, filters, sort_params)
+    Filtrator.filter(collection, params, filters)
   end
 
   def filter_params
@@ -16,7 +16,7 @@ module Filterable
   end
 
   def sort_params
-    params.fetch(:sort, '').split(',') if sorts_exist?
+    params.fetch(:sort, '').split(',') if filters.any? { |filter| filter.is_a?(Sort) }
   end
 
   def filters_valid?

--- a/lib/filterable/filter.rb
+++ b/lib/filterable/filter.rb
@@ -48,7 +48,7 @@ module Filterable
       end
     end
 
-    def apply!(collection, value:, active_sorts_hash:)
+    def apply!(collection, value:, active_sorts_hash:, params: {})
       if type == :scope
         if value.present?
           collection.public_send(internal_name, parameter(value))

--- a/lib/filterable/sort.rb
+++ b/lib/filterable/sort.rb
@@ -28,10 +28,10 @@ module Filterable
       false
     end
 
-    def apply!(collection, value:, active_sorts_hash:)
+    def apply!(collection, value:, active_sorts_hash:, params: {})
       if type == :scope
         if active_sorts_hash.keys.include?(param)
-          collection.public_send(internal_name, *mapped_scope_params(active_sorts_hash[param]))
+          collection.public_send(internal_name, *mapped_scope_params(active_sorts_hash[param], params))
         elsif default.present?
           # Stubbed because currently Filterable::Sort does not respect default
           # default.call(collection)
@@ -67,12 +67,14 @@ module Filterable
 
     private
 
-    def mapped_scope_params(direction)
+    def mapped_scope_params(direction, params)
       scope_params.map do |scope_param|
         if scope_param == :direction
           direction
         elsif scope_param.is_a?(Proc)
           scope_param.call
+        elsif params.include?(scope_param)
+          params[scope_param]
         else
           scope_param
         end

--- a/lib/filterable/version.rb
+++ b/lib/filterable/version.rb
@@ -1,3 +1,3 @@
 module Filterable
-  VERSION = '0.2.8'
+  VERSION = '0.2.9'
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -200,4 +200,13 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(@response.body, object_class: OpenStruct)
     assert_equal ['A', 'b', 'C', 'd'], json.map(&:title)
   end
+
+  test 'it sorts with dependent params' do
+    Post.create(body: 'b', expiration: "2017-11-11")
+    Post.create(body: 'A', expiration: "2017-10-10")
+    Post.create(body: 'C', expiration: "2090-08-08")
+    get('/posts', params: { sort: 'dynamic_sort', date: "2017-12-12" })
+    json = JSON.parse(@response.body)
+    assert_equal ['A', 'b'], json.map { |post| post.fetch("body") }
+  end
 end

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -34,6 +34,7 @@ class PostsController < ApplicationController
   sort_on :title, type: :string
   sort_on :priority, type: :string
   sort_on :foobar, type: :string, internal_name: :title
+  sort_on :dynamic_sort, type: :scope, internal_name: :expired_before_ordered_by_body, scope_params: [:date, :direction]
 
   def index
     render json: filtrate(Post.all)

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -22,4 +22,8 @@ class Post < ApplicationRecord
   scope :order_on_body_multi_param, -> (body, direction) {
     where(body: body).order(id: direction)
   }
+
+  scope :expired_before_ordered_by_body, -> (date, direction) {
+    expired_before(date).order_on_body_one_param(direction)
+  }
 end

--- a/test/filterable_test.rb
+++ b/test/filterable_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class FilterableTest < ActiveSupport::TestCase
   class MyClass
-    attr_accessor :params
+    attr_writer :params
     include Filterable
 
     def params

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -9,7 +9,7 @@ class FiltratorTest < ActiveSupport::TestCase
     post = Post.create!
     filter = Filterable::Filter.new(:id, :int, :id, nil)
 
-    collection = Filterable::Filtrator.filter(Post.all, { id: post.id }, [filter])
+    collection = Filterable::Filtrator.filter(Post.all, { filters: {id: post.id} }, [filter])
 
     assert_equal Post.where(id: post.id), collection
   end
@@ -18,7 +18,7 @@ class FiltratorTest < ActiveSupport::TestCase
     post = Post.create!(title: 'wow...man')
     filter = Filterable::Filter.new(:title, :string, :title, nil)
 
-    collection = Filterable::Filtrator.filter(Post.all, { title: post.title }, [filter])
+    collection = Filterable::Filtrator.filter(Post.all, { filters: {title: post.title} }, [filter])
 
     assert_equal Post.where(id: post.id).to_a, collection.to_a
   end
@@ -36,7 +36,7 @@ class FiltratorTest < ActiveSupport::TestCase
     Post.create!(body: "foo")
     filtered_post = Post.create!(body: "bar")
     filter = Filterable::Filter.new(:body2, :scope, :body2, nil)
-    collection = Filterable::Filtrator.filter(Post.all, { body2: "bar" }, [filter])
+    collection = Filterable::Filtrator.filter(Post.all, {filters: {body2: "bar"}}, [filter])
 
     assert_equal Post.where(id: filtered_post.id).to_a, collection.to_a
   end
@@ -46,7 +46,7 @@ class FiltratorTest < ActiveSupport::TestCase
     Post.create!(body: "bar", priority: 10)
     filtered_post = Post.create!(body: "foo", priority: 10)
     filter = Filterable::Filter.new(:body_and_priority, :scope, :body_and_priority, nil)
-    collection = Filterable::Filtrator.filter(Post.all, { body_and_priority: ["foo", 10] }, [filter])
+    collection = Filterable::Filtrator.filter(Post.all, { filters: { body_and_priority: ["foo", 10] } }, [filter])
 
     assert_equal Post.where(id: filtered_post.id).to_a, collection.to_a
   end
@@ -59,7 +59,7 @@ class FiltratorTest < ActiveSupport::TestCase
     # scopes that take no param seem silly, as the user's designation of sort direction would be rendered useless
     # unless the controller does some sort of parsing on user's input and handles the sort on its own
     # nonetheless, Filterable supports it :)
-    collection = Filterable::Filtrator.filter(Post.all, {}, [sort], ['-body'])
+    collection = Filterable::Filtrator.filter(Post.all, {sort: '-body'}, [sort])
 
     assert_equal Post.order_on_body_no_params.to_a, collection.to_a
   end
@@ -69,7 +69,7 @@ class FiltratorTest < ActiveSupport::TestCase
     Post.create!(body: 'aaaa')
     Post.create!(body: 'ffff')
     sort = Filterable::Sort.new(:body, :scope, :order_on_body_one_param, [:direction])
-    collection = Filterable::Filtrator.filter(Post.all, {}, [sort], ['-body'])
+    collection = Filterable::Filtrator.filter(Post.all, {sort: '-body'}, [sort])
 
     assert_equal Post.order_on_body_one_param(:desc).to_a, collection.to_a
   end
@@ -79,7 +79,7 @@ class FiltratorTest < ActiveSupport::TestCase
     Post.create!(body: 'aaaa')
     Post.create!(body: 'ffff')
     sort = Filterable::Sort.new(:body, :scope, :order_on_body_multi_param, ['aaaa', :direction])
-    collection = Filterable::Filtrator.filter(Post.all, {}, [sort], ['-body'])
+    collection = Filterable::Filtrator.filter(Post.all, {sort: '-body'}, [sort])
 
     assert_equal Post.order_on_body_multi_param('aaaa', :desc).to_a, collection.to_a
   end
@@ -89,8 +89,28 @@ class FiltratorTest < ActiveSupport::TestCase
     Post.create!(body: 'aaaa')
     Post.create!(body: 'ffff')
     sort = Filterable::Sort.new(:body, :scope, :order_on_body_multi_param, [lambda { 'aaaa' }, :direction])
-    collection = Filterable::Filtrator.filter(Post.all, {}, [sort], ['-body'])
+    collection = Filterable::Filtrator.filter(Post.all, {sort: '-body'}, [sort])
 
     assert_equal Post.order_on_body_multi_param('aaaa', :desc).to_a, collection.to_a
+  end
+
+  test "it can sort on scopes that require multiple dynamic arguments" do
+    Post.create!(body: 'zzzz', expiration: "2017-01-01")
+    Post.create!(body: 'aaaa', expiration: "2017-01-01")
+    Post.create!(body: 'ffff', expiration: "2020-10-20")
+    sort = Filterable::Sort.new(:dynamic_sort, :scope, :expired_before_ordered_by_body, [:date, :direction])
+    collection = Filterable::Filtrator.filter(Post.all, {date: "2017-12-31", sort: 'dynamic_sort', filters: {}}, [sort])
+
+    assert_equal 3, Post.count
+    assert_equal 2, Post.expired_before_ordered_by_body("2017-12-31", :asc).count
+    assert Post.expired_before_ordered_by_body("2017-12-31", :asc).first.body == "aaaa"
+    assert Post.expired_before_ordered_by_body("2017-12-31", :asc).last.body == "zzzz"
+
+    assert_equal 2, collection.count
+
+    assert collection.first.body == "aaaa"
+    assert collection.last.body == "zzzz"
+
+    assert_equal Post.expired_before_ordered_by_body('2017-12-31', :asc).to_a, collection.to_a
   end
 end

--- a/test/sort_test.rb
+++ b/test/sort_test.rb
@@ -17,7 +17,7 @@ class SortTest < ActiveSupport::TestCase
 
   test 'it raises if the scope params is not an array' do
     assert_raise RuntimeError do
-      sort = Filterable::Sort.new('hi', :int, 'hi', :direction)
+      Filterable::Sort.new('hi', :int, 'hi', :direction)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,8 +9,6 @@ require "rails/test_help"
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
-#Rails::TestUnitReporter.executable = 'bin/test'
-
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ require "rails/test_help"
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
-Rails::TestUnitReporter.executable = 'bin/test'
+#Rails::TestUnitReporter.executable = 'bin/test'
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)


### PR DESCRIPTION
### Changes
- Now passing in the entire params hash so that the sort method has access to any of those values

### Use Case
- We have a situation where access to the` project_id` was necessary for the particular sort scope we were using, and the current implementation didn't allow any way to access it.

### Sample
For a particular blog, we want to sort all posts by their authors, and need access to the `blog_id` to get said posts.
```ruby
   sort_on :post_authors, type: :scope, internal_name: :order_by_post_authors, scope_params: [:direction, :blog_id]
```
If `blog_id` exists in our params, we get the value of it and pass it on to our scope. 