### PR TITLE
IAM/filter access to params

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ you can pass an array of arguments instead of a single argument.
 
 Scopes that accept no arguments are currently not supported.
 
+#### Accessing Params with Filter Scopes
+
+Filters with `type: :scope` have access to the params hash by passing in the desired keys to the `scope_params`. The keys passed in must appear in the same order as the scope arguments they represent. 
+
+```ruby
+class Post < ActiveRecord::Base
+  scope :user_posts_on_date, ->(date, user_id, blog_id) { where(user_id: user_id, blog_id: blog_id, date: date) }
+end
+
+class UsersController < ApplicationController
+  include Filterable
+
+  filter_on :user_posts_on_date, type: :scope, scope_params: [:user_id, :blog_id]
+
+  def show
+    render json: filtrate(Post.all)
+  end
+end
+``` 
+Passing `?filters[user_posts_on_date]=10/12/20` will call the `user_posts_on_date` scope with
+`10/12/20` as the the first argument, and will grab the `user_id` and `blog_id` out of the params and pass them as the second and third arguments. 
+
 ### Sort Types
 Every sort must have a type, so that Filterable knows what to do with it. The current valid sort types are:
 * int - Sort on an integer column

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ Scopes that accept no arguments are currently not supported.
 
 #### Accessing Params with Filter Scopes
 
-Filters with `type: :scope` have access to the params hash by passing in the desired keys to the `scope_params`. The keys passed in must appear in the same order as the scope arguments they represent. 
+Filters with `type: :scope` have access to the params hash by passing in the desired keys to the `scope_params`. The keys passed in will be returned as a hash with their associated values, and should always appear as the last argument in your scope.  
 
 ```ruby
 class Post < ActiveRecord::Base
-  scope :user_posts_on_date, ->(date, user_id, blog_id) { where(user_id: user_id, blog_id: blog_id, date: date) }
+  scope :user_posts_on_date, ->(date, options) { where(user_id: user_id, blog_id: options[:blog_id], date: options[:date]) }
 end
 
 class UsersController < ApplicationController
@@ -93,7 +93,7 @@ class UsersController < ApplicationController
 end
 ``` 
 Passing `?filters[user_posts_on_date]=10/12/20` will call the `user_posts_on_date` scope with
-`10/12/20` as the the first argument, and will grab the `user_id` and `blog_id` out of the params and pass them as the second and third arguments. 
+`10/12/20` as the the first argument, and will grab the `user_id` and `blog_id` out of the params and pass them as a hash, as the second argument.  
 
 ### Sort Types
 Every sort must have a type, so that Filterable knows what to do with it. The current valid sort types are:

--- a/lib/filterable.rb
+++ b/lib/filterable.rb
@@ -42,8 +42,8 @@ module Filterable
   end
 
   class_methods do
-    def filter_on(parameter, type:, internal_name: parameter, default: nil, validate: nil)
-      filters << Filter.new(parameter, type, internal_name, default, validate)
+    def filter_on(parameter, type:, internal_name: parameter, default: nil, validate: nil, scope_params: [])
+      filters << Filter.new(parameter, type, internal_name, default, validate, scope_params)
     end
 
     def filters

--- a/lib/filterable/filter.rb
+++ b/lib/filterable/filter.rb
@@ -52,8 +52,10 @@ module Filterable
 
     def apply!(collection, value:, active_sorts_hash:, params: {})
       if type == :scope
-        if value.present?
-          collection.public_send(internal_name, parameter(value), *mapped_scope_params(params))
+        if value.present? && scope_params.empty?
+          collection.public_send(internal_name, parameter(value))
+        elsif value.present? && scope_params.any?
+          collection.public_send(internal_name, parameter(value), mapped_scope_params(params))
         elsif default.present?
           default.call(collection)
         else
@@ -75,8 +77,8 @@ module Filterable
     private
 
     def mapped_scope_params(params)
-      scope_params.map do |scope_param|
-          params.fetch(scope_param)
+      scope_params.each_with_object({}) do |scope_param,hash|
+          hash[scope_param] = params.fetch(scope_param)
       end
     end
 

--- a/lib/filterable/filter.rb
+++ b/lib/filterable/filter.rb
@@ -22,6 +22,7 @@ module Filterable
 
     def initialize(param, type, internal_name, default, custom_validate = nil, scope_params = [])
       raise "unknown filter type: #{type}" unless WHITELIST_TYPES.include?(type)
+      raise ArgumentError, 'scope_params must be an array of symbols' unless valid_scope_params(scope_params)
       @param = param
       @type = type
       @internal_name = internal_name || @param
@@ -51,10 +52,8 @@ module Filterable
 
     def apply!(collection, value:, active_sorts_hash:, params: {})
       if type == :scope
-        if scope_params && value.present?
+        if value.present?
           collection.public_send(internal_name, parameter(value), *mapped_scope_params(params))
-        elsif value.present?
-          collection.public_send(internal_name, parameter(value))
         elsif default.present?
           default.call(collection)
         else
@@ -93,6 +92,10 @@ module Filterable
       else
         value
       end
+    end
+
+    def valid_scope_params(scope_params)
+      scope_params.is_a?(Array) && scope_params.all? { |symbol| symbol.is_a?(Symbol) }
     end
   end
 end

--- a/lib/filterable/version.rb
+++ b/lib/filterable/version.rb
@@ -1,3 +1,3 @@
 module Filterable
-  VERSION = '0.2.9'
+  VERSION = '0.3.0'
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -202,19 +202,23 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'it sorts with dependent params' do
-    Post.create(body: 'b', expiration: "2017-11-11")
-    Post.create(body: 'A', expiration: "2017-10-10")
-    Post.create(body: 'C', expiration: "2090-08-08")
+    Post.create!(body: 'b', expiration: "2017-11-11")
+    Post.create!(body: 'A', expiration: "2017-10-10")
+    Post.create!(body: 'C', expiration: "2090-08-08")
+
     get('/posts', params: { sort: 'dynamic_sort', date: "2017-12-12" })
     json = JSON.parse(@response.body)
+
     assert_equal ['A', 'b'], json.map { |post| post.fetch("body") }
   end
 
   test 'it filters with dependent params' do
-    Post.create(priority: 7, expiration: "2017-11-11")
-    Post.create(priority: 3, expiration: "2017-10-10")
+    Post.create!(priority: 7, expiration: "2017-11-11")
+    Post.create!(priority: 5, expiration: "2017-10-10")
+
     get('/posts', params: { filters: { expired_before_and_priority: "2017-12-12"}, priority: 5})
     json = JSON.parse(@response.body)
-    assert_equal [3], json.map { |post| post.fetch("priority") }
+
+    assert_equal [5], json.map { |post| post.fetch("priority") }
   end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -209,4 +209,12 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(@response.body)
     assert_equal ['A', 'b'], json.map { |post| post.fetch("body") }
   end
+
+  test 'it filters with dependent params' do
+    Post.create(priority: 7, expiration: "2017-11-11")
+    Post.create(priority: 3, expiration: "2017-10-10")
+    get('/posts', params: { filters: { expired_before_and_priority: "2017-12-12"}, priority: 5})
+    json = JSON.parse(@response.body)
+    assert_equal [3], json.map { |post| post.fetch("priority") }
+  end
 end

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -11,6 +11,7 @@ class PostsController < ApplicationController
   filter_on :hidden_after, type: :time
   filter_on :published_at, type: :datetime
   filter_on :expired_before, type: :scope
+  filter_on :expired_before_and_priority, type: :scope, scope_params: [:priority]
 
   filter_on :french_bread, type: :string, internal_name: :title
   filter_on :body2, type: :scope, internal_name: :body2, default: ->(c) { c.order(:body) }

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -27,11 +27,11 @@ class Post < ApplicationRecord
     expired_before(date).order_on_body_one_param(direction)
   }
 
-  scope :expired_before_and_priority, -> (date, priority) {
-    expired_before(date).where(priority: priority)
+  scope :expired_before_and_priority, -> (date, options) {
+    expired_before(date).where(priority: options[:priority])
   }
 
-  scope :ordered_expired_before_and_priority, -> (direction, date, priority) {
-    expired_before_and_priority(date,priority).order(id: direction)
+  scope :ordered_expired_before_and_priority, -> (direction, options) {
+    expired_before_and_priority(options[:date],options).order(id: direction)
   }
 end

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -26,4 +26,12 @@ class Post < ApplicationRecord
   scope :expired_before_ordered_by_body, -> (date, direction) {
     expired_before(date).order_on_body_one_param(direction)
   }
+
+  scope :expired_before_and_priority, -> (date, priority) {
+    expired_before(date).where('priority <= ?', priority)
+  }
+
+  scope :ordered_expired_before_and_priority, -> (direction, date, priority) {
+    expired_before_and_priority(date,priority).order(id: direction)
+  }
 end

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -28,7 +28,7 @@ class Post < ApplicationRecord
   }
 
   scope :expired_before_and_priority, -> (date, priority) {
-    expired_before(date).where('priority <= ?', priority)
+    expired_before(date).where(priority: priority)
   }
 
   scope :ordered_expired_before_and_priority, -> (direction, date, priority) {

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -15,6 +15,18 @@ class FilterTest < ActiveSupport::TestCase
     end
   end
 
+  test 'it raises an exception if scope_params is not an array' do
+    assert_raise ArgumentError do
+      Filterable::Filter.new('hi', :scope, 'hi', nil, nil, {})
+    end
+  end
+
+  test 'it raises an exception if scope_params does not contain symbols' do
+    assert_raise ArgumentError do
+      Filterable::Filter.new('hi', :scope, 'hi', nil, nil, ['foo'])
+    end
+  end
+
   test 'it knows what validation it needs when a datetime' do
     filter = Filterable::Filter.new('hi', :datetime, 'hi', nil)
     expected_validation = { format: { with: /\A.+(?:[^.]\.\.\.[^.]).+\z/ , message: "must be a range" } }

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -59,10 +59,10 @@ class FiltratorTest < ActiveSupport::TestCase
     collection = Filterable::Filtrator.filter(Post.all, { filters: { expired_before_and_priority: "2017-12-31"}, priority: 5 }, [filter])
 
     assert_equal 3, Post.count
-    assert_equal 2, Post.expired_before_and_priority("2017-12-31", 5).count
+    assert_equal 2, Post.expired_before_and_priority("2017-12-31", { priority: 5 }).count
     assert_equal 2, collection.count
 
-    assert_equal Post.expired_before_and_priority('2017-12-31', 5).to_a, collection.to_a
+    assert_equal Post.expired_before_and_priority('2017-12-31', { priority: 5 }).to_a, collection.to_a
   end
 
   test 'it can filter on scopes that need multiple values from params' do
@@ -74,10 +74,10 @@ class FiltratorTest < ActiveSupport::TestCase
     collection = Filterable::Filtrator.filter(Post.all, { filters: { ordered_expired_before_and_priority: 'ASC'}, priority: 5, date: "2017-12-31"}, [filter])
 
     assert_equal 3, Post.count
-    assert_equal 2, Post.ordered_expired_before_and_priority("ASC","2017-12-31", 5).count
+    assert_equal 2, Post.ordered_expired_before_and_priority("ASC", { date: "2017-12-31", priority: 5 }).count
     assert_equal 2, collection.count
 
-    assert_equal Post.ordered_expired_before_and_priority("ASC","2017-12-31", 5).to_a, collection.to_a
+    assert_equal Post.ordered_expired_before_and_priority("ASC", { date: "2017-12-31", priority: 5 }).to_a, collection.to_a
   end
 
   test 'it can sort on scopes that do not require arguments' do

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -52,8 +52,8 @@ class FiltratorTest < ActiveSupport::TestCase
   end
 
   test 'it can filter on scopes that need values from params' do
-    Post.create!(priority: 1, expiration: "2017-01-01")
-    Post.create!(priority: 3, expiration: "2017-01-02")
+    Post.create!(priority: 5, expiration: "2017-01-01")
+    Post.create!(priority: 5, expiration: "2017-01-02")
     Post.create!(priority: 7, expiration: "2020-10-20")
     filter = Filterable::Filter.new(:expired_before_and_priority, :scope, :expired_before_and_priority, nil, nil, [:priority])
     collection = Filterable::Filtrator.filter(Post.all, { filters: { expired_before_and_priority: "2017-12-31"}, priority: 5 }, [filter])
@@ -66,8 +66,8 @@ class FiltratorTest < ActiveSupport::TestCase
   end
 
   test 'it can filter on scopes that need multiple values from params' do
-    Post.create!(priority: 1, expiration: "2017-01-01")
-    Post.create!(priority: 3, expiration: "2017-01-02")
+    Post.create!(priority: 5, expiration: "2017-01-01")
+    Post.create!(priority: 5, expiration: "2017-01-02")
     Post.create!(priority: 7, expiration: "2020-10-20")
 
     filter = Filterable::Filter.new(:ordered_expired_before_and_priority, :scope, :ordered_expired_before_and_priority, nil, nil, [:date, :priority])

--- a/test/filtrator_test.rb
+++ b/test/filtrator_test.rb
@@ -51,6 +51,35 @@ class FiltratorTest < ActiveSupport::TestCase
     assert_equal Post.where(id: filtered_post.id).to_a, collection.to_a
   end
 
+  test 'it can filter on scopes that need values from params' do
+    Post.create!(priority: 1, expiration: "2017-01-01")
+    Post.create!(priority: 3, expiration: "2017-01-02")
+    Post.create!(priority: 7, expiration: "2020-10-20")
+    filter = Filterable::Filter.new(:expired_before_and_priority, :scope, :expired_before_and_priority, nil, nil, [:priority])
+    collection = Filterable::Filtrator.filter(Post.all, { filters: { expired_before_and_priority: "2017-12-31"}, priority: 5 }, [filter])
+
+    assert_equal 3, Post.count
+    assert_equal 2, Post.expired_before_and_priority("2017-12-31", 5).count
+    assert_equal 2, collection.count
+
+    assert_equal Post.expired_before_and_priority('2017-12-31', 5).to_a, collection.to_a
+  end
+
+  test 'it can filter on scopes that need multiple values from params' do
+    Post.create!(priority: 1, expiration: "2017-01-01")
+    Post.create!(priority: 3, expiration: "2017-01-02")
+    Post.create!(priority: 7, expiration: "2020-10-20")
+
+    filter = Filterable::Filter.new(:ordered_expired_before_and_priority, :scope, :ordered_expired_before_and_priority, nil, nil, [:date, :priority])
+    collection = Filterable::Filtrator.filter(Post.all, { filters: { ordered_expired_before_and_priority: 'ASC'}, priority: 5, date: "2017-12-31"}, [filter])
+
+    assert_equal 3, Post.count
+    assert_equal 2, Post.ordered_expired_before_and_priority("ASC","2017-12-31", 5).count
+    assert_equal 2, collection.count
+
+    assert_equal Post.ordered_expired_before_and_priority("ASC","2017-12-31", 5).to_a, collection.to_a
+  end
+
   test 'it can sort on scopes that do not require arguments' do
     Post.create!(body: 'zzzz')
     Post.create!(body: 'aaaa')


### PR DESCRIPTION
### Changes
- Filter now takes an optional argument `scope_params`, that defaults to an empty array. This array should contain symbols that represent keys in the params hash which will be used as arguments in the provided scope. 
- Unlike `sort_on`, if you pass `scope_params` to `filter_on`, it should ***only*** contain the keys in the params hash that you intend to access the values for. Much like the `sort_on` implementation of `scope_params`, the symbols passed in are order dependent and will be passed back as arguments to the scope in the order provided. 
- If `scope_params` is passed as an argument and it is not an empty array, or an array that contains symbols, an `ArgumentError` will be raised

### Use Case
- See the updated `README` for an example, but essentially we needed a way to pull some values out of the params hash for one or two of our filters.