### PR TITLE
Fix Scopes with Params Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ Filters with `type: :scope` have access to the params hash by passing in the des
 
 ```ruby
 class Post < ActiveRecord::Base
-  scope :user_posts_on_date, ->(date, options) { where(user_id: user_id, blog_id: options[:blog_id], date: options[:date]) }
+  scope :user_posts_on_date, ->(date, options) {
+    where(user_id: options[:user_id], blog_id: options[:blog_id], date: date)
+  }
 end
 
 class UsersController < ApplicationController


### PR DESCRIPTION
Have the code example match the description:
> Passing `?filters[user_posts_on_date]=10/12/20` will call the `user_posts_on_date` scope with `10/12/20` as the the first argument, and will grab the `user_id` and `blog_id` out of the params and pass them as a hash, as the second argument.