### PR TITLE
Fix Documentation for Scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ end
 class PostsController < ApplicationController
   include Filterable
 
-  filter_on :with_body, type: :text
+  filter_on :with_body, type: :scope
 
   def index
     render json: filtrate(Post.all)


### PR DESCRIPTION
When specifying `type: :string` for my scope filter, I receive the following:
```
ERROR: column my_table.my_scope does not exist
```
Changing it to `type: :scope`, everything works.

Reason, it's filtering on an ActiveRecord scope not string column.