### PR TITLE
Document internal_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ end
 Passing `?filters[user_posts_on_date]=10/12/20` will call the `user_posts_on_date` scope with
 `10/12/20` as the the first argument, and will grab the `user_id` and `blog_id` out of the params and pass them as a hash, as the second argument.  
 
+### Renaming Filter Params
+
+A filter param can have a different field name than the column or scope. Use `internal_name` with the correct name of the column or scope.
+
+```ruby
+class PostsController < ApplicationController
+  include Filterable
+
+  filter_on :post_id, type: :int, internal_name: :id
+
+end
+```
+
 ### Sort Types
 Every sort must have a type, so that Filterable knows what to do with it. The current valid sort types are:
 * int - Sort on an integer column


### PR DESCRIPTION
Add missing documentation for `internal_name` which maps a custom filter name to the correct column or scope name.