### PR TITLE
Allow array of integers for type: int

### DIFF
--- a/lib/filterable.rb
+++ b/lib/filterable.rb
@@ -4,6 +4,7 @@ require 'filterable/filtrator'
 require 'filterable/sort'
 require 'filterable/subset_comparator'
 require 'filterable/type_validator'
+require 'filterable/validators/valid_int_validator'
 
 module Filterable
   extend ActiveSupport::Concern

--- a/lib/filterable.rb
+++ b/lib/filterable.rb
@@ -3,6 +3,7 @@ require 'filterable/filter_validator'
 require 'filterable/filtrator'
 require 'filterable/sort'
 require 'filterable/subset_comparator'
+require 'filterable/type_validator'
 
 module Filterable
   extend ActiveSupport::Concern

--- a/lib/filterable/filter.rb
+++ b/lib/filterable/filter.rb
@@ -40,7 +40,7 @@ module Filterable
       when :datetime, :date, :time
         RANGE_PATTERN
       when :int
-        DIGIT_RANGE_PATTERN
+        valid_int?
       when :decimal
         DECIMAL_PATTERN
       when :boolean
@@ -98,6 +98,14 @@ module Filterable
 
     def valid_scope_params(scope_params)
       scope_params.is_a?(Array) && scope_params.all? { |symbol| symbol.is_a?(Symbol) }
+    end
+
+    def valid_int?
+      is_int_array? || DIGIT_RANGE_PATTERN 
+    end
+
+    def is_int_array?
+      param.is_a?(Array) && param.any? && param.all? { |param| param.is_a?(Integer) }
     end
   end
 end

--- a/lib/filterable/filter_validator.rb
+++ b/lib/filterable/filter_validator.rb
@@ -40,7 +40,6 @@ module Filterable
 
       class_eval do
         attr_accessor(*unique_validations.map(&:validation_field))
-
         unique_validations.each do |filter|
           if (params.fetch(:filters, {})[filter.validation_field] && filter.custom_validate)
             validate filter.custom_validate

--- a/lib/filterable/filter_validator.rb
+++ b/lib/filterable/filter_validator.rb
@@ -36,11 +36,12 @@ module Filterable
     end
 
     def add_validations(filters, params, sort_fields)
-      unique_validations = filters.uniq { |filter| filter.validation_field }
+      unique_validations_filters = filters.uniq { |filter| filter.validation_field }
 
       class_eval do
-        attr_accessor(*unique_validations.map(&:validation_field))
-        unique_validations.each do |filter|
+
+        attr_accessor(*unique_validations_filters.map(&:validation_field))
+        unique_validations_filters.each do |filter|
           if (params.fetch(:filters, {})[filter.validation_field] && filter.custom_validate)
             validate filter.custom_validate
           elsif (params.fetch(:filters, {})[filter.validation_field] && filter.validation(sort_fields)) || filter.validation_field == :sort

--- a/lib/filterable/type_validator.rb
+++ b/lib/filterable/type_validator.rb
@@ -2,9 +2,18 @@ module Filterable
   # TypeValidator validates that the incoming param is of the specified type
   class TypeValidator
     RANGE_PATTERN = { format: { with: /\A.+(?:[^.]\.\.\.[^.]).+\z/, message: 'must be a range' } }.freeze
-    DIGIT_RANGE_PATTERN = { format: { with: /\A\d+(...\d+)?\z/, message: 'must be int or range' } }.freeze
     DECIMAL_PATTERN = { numericality: true, allow_nil: true }.freeze
     BOOLEAN_PATTERN = { inclusion: { in: [true, false] }, allow_nil: true }.freeze
+
+    WHITELIST_TYPES = [:int,
+                       :decimal,
+                       :boolean,
+                       :string,
+                       :text,
+                       :date,
+                       :time,
+                       :datetime,
+                       :scope].freeze
 
     def initialize(param, type)
       @param = param
@@ -28,14 +37,14 @@ module Filterable
       end
     end
 
+    def valid_type?
+      WHITELIST_TYPES.include?(type)
+    end
+
     private
 
     def valid_int?
-      is_int_array? || DIGIT_RANGE_PATTERN 
-    end
-
-    def is_int_array?
-      param.is_a?(Array) && param.any? && param.all? { |param| param.is_a?(Integer) }
+      { valid_int: true }
     end
   end
 end

--- a/lib/filterable/type_validator.rb
+++ b/lib/filterable/type_validator.rb
@@ -1,0 +1,41 @@
+module Filterable
+  # TypeValidator validates that the incoming param is of the specified type
+  class TypeValidator
+    RANGE_PATTERN = { format: { with: /\A.+(?:[^.]\.\.\.[^.]).+\z/, message: 'must be a range' } }.freeze
+    DIGIT_RANGE_PATTERN = { format: { with: /\A\d+(...\d+)?\z/, message: 'must be int or range' } }.freeze
+    DECIMAL_PATTERN = { numericality: true, allow_nil: true }.freeze
+    BOOLEAN_PATTERN = { inclusion: { in: [true, false] }, allow_nil: true }.freeze
+
+    def initialize(param, type)
+      @param = param
+      @type = type
+    end
+
+    attr_reader :param, :type
+
+    def validate
+      case type
+      when :datetime, :date, :time
+        RANGE_PATTERN
+      when :int
+        valid_int?
+      when :decimal
+        DECIMAL_PATTERN
+      when :boolean
+        BOOLEAN_PATTERN
+      when :string
+      when :text
+      end
+    end
+
+    private
+
+    def valid_int?
+      is_int_array? || DIGIT_RANGE_PATTERN 
+    end
+
+    def is_int_array?
+      param.is_a?(Array) && param.any? && param.all? { |param| param.is_a?(Integer) }
+    end
+  end
+end

--- a/lib/filterable/validators/valid_int_validator.rb
+++ b/lib/filterable/validators/valid_int_validator.rb
@@ -1,13 +1,13 @@
 class ValidIntValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add attribute, (options[:message] || "must be int or range") unless
+    record.errors.add attribute, (options[:message] || "must be integer, array of integers, or range") unless
       valid_int?(value)
   end
 
   private
 
   def valid_int?(value)
-    is_integer_array?(value) || is_integer_or_range?(value)
+    is_integer_or_range?(value) || is_integer_array?(value)
   end
 
   def is_integer_array?(value)

--- a/lib/filterable/validators/valid_int_validator.rb
+++ b/lib/filterable/validators/valid_int_validator.rb
@@ -7,14 +7,14 @@ class ValidIntValidator < ActiveModel::EachValidator
   private
 
   def valid_int?(value)
-    is_integer_or_range?(value) || is_integer_array?(value)
+    is_integer_array?(value) || is_integer_or_range?(value)
   end
 
   def is_integer_array?(value)
-    value.is_a?(Array) && value.any? && value.all? { |value| value.is_a?(Integer) }
+    value.is_a?(Array) && value.any? && value.all? { |value| is_integer_or_range?(value) }
   end
 
   def is_integer_or_range?(value)
-    value.is_a?(Integer) || !!(/\A\d+(...\d+)?\z/ =~ value)
+    !!(/\A\d+(...\d+)?\z/ =~ value)
   end
 end

--- a/lib/filterable/validators/valid_int_validator.rb
+++ b/lib/filterable/validators/valid_int_validator.rb
@@ -1,0 +1,20 @@
+class ValidIntValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add attribute, (options[:message] || "must be int or range") unless
+      valid_int?(value)
+  end
+
+  private
+
+  def valid_int?(value)
+    is_integer_array?(value) || is_integer_or_range?(value)
+  end
+
+  def is_integer_array?(value)
+    value.is_a?(Array) && value.any? && value.all? { |value| value.is_a?(Integer) }
+  end
+
+  def is_integer_or_range?(value)
+    value.is_a?(Integer) || !!(/\A\d+(...\d+)?\z/ =~ value)
+  end
+end

--- a/lib/filterable/version.rb
+++ b/lib/filterable/version.rb
@@ -1,3 +1,3 @@
 module Filterable
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -58,7 +58,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   test 'it invalidates id' do
     Post.create!(visible: false)
     Post.create!
-    expected_json = { 'errors' => { 'id' => ['must be int or range'] } }
+    expected_json = { 'errors' => { 'id' => ['must be integer, array of integers, or range'] } }
 
 
     get('/posts', params: { filters: { id: 'poopie' } })

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -80,7 +80,14 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'it filters on id with an array' do
+    post = Post.create!
+    post2 = Post.create!
+    Post.create!
 
+    get('/posts', params: { filters: { id: [post.id, post2.id] } })
+
+    json = JSON.parse(@response.body)
+    assert_equal 2, json.size
   end
 
   test 'it filters on named scope' do

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -36,27 +36,28 @@ class FilterTest < ActiveSupport::TestCase
 
   test 'it knows what validation it needs when an int' do
     filter = Filterable::Filter.new('hi', :int, 'hi', nil)
-    expected_validation = { format: { with: /\A\d+(...\d+)?\z/ , message: "must be int or range" } }
+    expected_validation = { :valid_int => true }
 
     assert_equal expected_validation, filter.validation(nil)
   end
 
   test 'it accepts a singular int or array of ints' do
     filter = Filterable::Filter.new([1,2], :int, [1,2], nil)
+    expected_validation = { :valid_int => true }
 
-    assert_equal true, filter.validation(nil)
+    assert_equal expected_validation, filter.validation(nil)
   end
 
   test 'it does not accept a mixed array when the type is int' do
     filter = Filterable::Filter.new([1,2,"a"], :int, [1,2,"a"], nil)
-    expected_validation = { format: { with: /\A\d+(...\d+)?\z/, message: 'must be int or range' } }
+    expected_validation = { :valid_int => true }
 
     assert_equal expected_validation, filter.validation(nil)
   end
 
   test 'it does not accept an empty array for type int' do
     filter = Filterable::Filter.new([], :int, [], nil)
-    expected_validation = { format: { with: /\A\d+(...\d+)?\z/, message: 'must be int or range' } }
+    expected_validation = { :valid_int => true }
 
     assert_equal expected_validation, filter.validation(nil)
   end

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -41,6 +41,26 @@ class FilterTest < ActiveSupport::TestCase
     assert_equal expected_validation, filter.validation(nil)
   end
 
+  test 'it accepts a singular int or array of ints' do
+    filter = Filterable::Filter.new([1,2], :int, [1,2], nil)
+
+    assert_equal true, filter.validation(nil)
+  end
+
+  test 'it does not accept a mixed array when the type is int' do
+    filter = Filterable::Filter.new([1,2,"a"], :int, [1,2,"a"], nil)
+    expected_validation = { format: { with: /\A\d+(...\d+)?\z/, message: 'must be int or range' } }
+
+    assert_equal expected_validation, filter.validation(nil)
+  end
+
+  test 'it does not accept an empty array for type int' do
+    filter = Filterable::Filter.new([], :int, [], nil)
+    expected_validation = { format: { with: /\A\d+(...\d+)?\z/, message: 'must be int or range' } }
+
+    assert_equal expected_validation, filter.validation(nil)
+  end
+
   test 'it knows what validation it needs when a decimal' do
     filter = Filterable::Filter.new('hi', :decimal, 'hi', nil)
     expected_validation = { numericality: true, allow_nil: true }

--- a/test/filter_validator_test.rb
+++ b/test/filter_validator_test.rb
@@ -11,7 +11,7 @@ class FilterValidatorTest < ActiveSupport::TestCase
 
   test 'it validates integers cannot be strings' do
     filter = Filterable::Filter.new(:hi, :int, :hi, nil)
-    expected_messages = { hi: ["must be int or range"] }
+    expected_messages = { hi: ["must be integer, array of integers, or range"] }
 
     validator = Filterable::FilterValidator.new([filter], {filters: { hi: 'hi123' }}, [], filter_params: { hi: 'hi123' }, sort_params: '')
     assert !validator.valid?

--- a/test/filter_validator_test.rb
+++ b/test/filter_validator_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class FilterValidatorTest < ActiveSupport::TestCase
   test 'it validates that integers are numeric integers' do
     filter = Filterable::Filter.new(:hi, :int, :hi, nil)
-    validator = Filterable::FilterValidator.new([filter], {filters: { hi: 1 }}, [], filter_params: { hi: 1}, sort_params: '')
+    validator = Filterable::FilterValidator.new([filter], {filters: { hi: '1' }}, [], filter_params: { hi: '1'}, sort_params: '')
 
     assert validator.valid?
     assert_equal Hash.new, validator.errors.messages

--- a/test/filter_validator_test.rb
+++ b/test/filter_validator_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class FilterValidatorTest < ActiveSupport::TestCase
   test 'it validates that integers are numeric integers' do
     filter = Filterable::Filter.new(:hi, :int, :hi, nil)
-
     validator = Filterable::FilterValidator.new([filter], {filters: { hi: 1 }}, [], filter_params: { hi: 1}, sort_params: '')
+
     assert validator.valid?
     assert_equal Hash.new, validator.errors.messages
   end

--- a/test/type_validator_test.rb
+++ b/test/type_validator_test.rb
@@ -7,6 +7,12 @@ class TypeValidatorTest < ActiveSupport::TestCase
     assert_equal false, validator.valid_type?
   end
 
+  test 'it accepts types that are whitelisted' do
+    validator = Filterable::TypeValidator.new("test", :string)
+
+    assert_equal true, validator.valid_type?
+  end
+
   test 'it accepts arrays of integers for type int' do
     validator = Filterable::TypeValidator.new([1,2], :int)
     expected_validation = { :valid_int => true }
@@ -16,6 +22,13 @@ class TypeValidatorTest < ActiveSupport::TestCase
 
   test 'it accepts a single integer for type int' do
     validator = Filterable::TypeValidator.new(1, :int)
+    expected_validation = { :valid_int => true }
+
+    assert_equal expected_validation, validator.validate
+  end
+
+  test 'it accepts a range for type int' do
+    validator = Filterable::TypeValidator.new("1..10", :int)
     expected_validation = { :valid_int => true }
 
     assert_equal expected_validation, validator.validate

--- a/test/type_validator_test.rb
+++ b/test/type_validator_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class TypeValidatorTest < ActiveSupport::TestCase
+  test 'it does not accept a type that is not whitelisted' do
+    validator = Filterable::TypeValidator.new("test", :foo_bar)
+
+    assert_equal false, validator.valid_type?
+  end
+
+  test 'it accepts arrays of integers for type int' do
+    validator = Filterable::TypeValidator.new([1,2], :int)
+    expected_validation = { :valid_int => true }
+
+    assert_equal expected_validation, validator.validate
+  end
+
+  test 'it accepts a single integer for type int' do
+    validator = Filterable::TypeValidator.new(1, :int)
+    expected_validation = { :valid_int => true }
+
+    assert_equal expected_validation, validator.validate
+  end
+end


### PR DESCRIPTION
### Changes
- Extracted all type checking logic from `Filter` class, to a separate `TypeValidator` class. 
- Added a custom validation for the `integer` type, that allows anything of type int to be valid if it is a : `int`, `range`, `array of ints`

### Use case
- We have a bunch of scopes that basically all say for this field, allow an array of integers. This helps us clean up and get rid of these scopes, by just allowing this with the integer type instead. 